### PR TITLE
Fix error identified by W3C CSS validation service

### DIFF
--- a/github-markdown.css
+++ b/github-markdown.css
@@ -532,7 +532,7 @@
 }
 
 .markdown-body li {
-  word-wrap: break-all;
+  word-wrap: break-word;
 }
 
 .markdown-body li>p {
@@ -642,7 +642,6 @@
 
 .markdown-body pre code {
   display: inline;
-  max-width: auto;
   padding: 0;
   margin: 0;
   overflow: visible;


### PR DESCRIPTION
The validation tool can be found here:
https://jigsaw.w3.org/css-validator

Errors that were identified were the following:
1  .markdown-body li break-all is not a overflow-wrap value : break-all
1  .markdown-body pre code Value Error : max-width Too many values or values are not recognized : auto