### PR TITLE
Remove duplicate line-height

### DIFF
--- a/github-markdown.css
+++ b/github-markdown.css
@@ -10,7 +10,6 @@
   color: #24292e;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
-  line-height: 1.5;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
Just noticed duplicate `line-height: 1.5;` in `.markdown-body`, so I removed it.