### PR TITLE
Add render instruction for code syntax highlighting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,8 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
+If you want code syntax highlight use GitHub Flavored Markdown generated from [their `/markdown` API](https://developer.github.com/v3/markdown/).
+
 
 ## How
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
-If you want a code syntax highlight, use the GitHub Flavored Markdown rendered from [their `/markdown` API](https://developer.github.com/v3/markdown/).
+If you want code syntax highlighted, use GitHub Flavored Markdown rendered from [GitHub's `/markdown` API](https://developer.github.com/v3/markdown/).
 
 
 ## How

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
-If you want code syntax highlight use GitHub Flavored Markdown generated from [their `/markdown` API](https://developer.github.com/v3/markdown/).
+If you want a code syntax highlight, use the GitHub Flavored Markdown rendered from [their `/markdown` API](https://developer.github.com/v3/markdown/).
 
 
 ## How


### PR DESCRIPTION
I had to google around why the code syntax didn't work when I was using marked.js rendered Markdown. Would be nice to include some instruction for someone like me in the future

Fixes #18