### PR TITLE
Fix "Fork me on Github" image

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,12 @@
 				padding: 45px;
 			}
 		</style>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
+        <style type="text/css">
+            .github-fork-ribbon:before {
+                background-color: #121612;
+            }
+        </style>
 	</head>
 	<body>
 		<article class="markdown-body">
@@ -1849,6 +1855,6 @@ gulp.task(<span class="pl-s"><span class="pl-pds">'</span>default<span class="pl
         .pipe(gulp.dest(<span class="pl-s"><span class="pl-pds">'</span>dist<span class="pl-pds">'</span></span>));
 });</pre></div>
 		</article>
-		<a href="https://github.com/sindresorhus/github-markdown-css"><img style="position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px;" src="http://aral.github.com/fork-me-on-github-retina-ribbons/right-graphite@2x.png" alt="Fork me on GitHub"></a>
+        <a class="github-fork-ribbon" href="https://github.com/sindresorhus/github-markdown-css" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
 				padding: 45px;
 			}
 		</style>
-        	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
-        	<style type="text/css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
+		<style type="text/css">
 			.github-fork-ribbon:before {
-                		background-color: #121612;
-            		}
-        	</style>
+				background-color: #121612;
+			}
+		</style>
 	</head>
 	<body>
 		<article class="markdown-body">
@@ -1855,6 +1855,6 @@ gulp.task(<span class="pl-s"><span class="pl-pds">'</span>default<span class="pl
         .pipe(gulp.dest(<span class="pl-s"><span class="pl-pds">'</span>dist<span class="pl-pds">'</span></span>));
 });</pre></div>
 		</article>
-        <a class="github-fork-ribbon" href="https://github.com/sindresorhus/github-markdown-css" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
+		<a class="github-fork-ribbon" href="https://github.com/sindresorhus/github-markdown-css" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
 				padding: 45px;
 			}
 		</style>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
-		<style type="text/css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css">
+		<style>
 			.github-fork-ribbon:before {
 				background-color: #121612;
 			}

--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
 				padding: 45px;
 			}
 		</style>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
-        <style type="text/css">
-            .github-fork-ribbon:before {
-                background-color: #121612;
-            }
-        </style>
+        	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
+        	<style type="text/css">
+			.github-fork-ribbon:before {
+                		background-color: #121612;
+            		}
+        	</style>
 	</head>
 	<body>
 		<article class="markdown-body">


### PR DESCRIPTION
The image "Fork me on Github" in the demo was corrupted. 

Because [aral/fork-me-on-github-retina-ribbons](https://github.com/aral/fork-me-on-github-retina-ribbons) that was used has stopped working, I replaced the image with css.

Be careful if you are using it in other repositories as well.