### PR TITLE
Add GitHub action to update files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "npm"
+
+      - name: Build
+        run: npm install && npm run make
+
+      - name: Commit
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Regenerate GitHub CSS" -a
+
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}


### PR DESCRIPTION
Sorry for the late update to 5.0.1. But I was unable to run `generate-github-markdown-css` for a long time due to the network issue in my country. So I decided to write a github action to overcome that. It works in my [repo](https://github.com/hyrious/github-markdown-css/actions).

The action is marked as `workflow_dispatch:` so that it is only triggered manually. The workflow will be:

1. update `devDependencies` in package.json, push
2. trigger this action to update css files
3. `git pull`
4. update `version` in package.json then `npm publish`

You can close this PR if it does not suit your opinion.