### PR TITLE
fix: don't break words in table

### DIFF
--- a/github-markdown-dark.css
+++ b/github-markdown-dark.css
@@ -216,6 +216,7 @@
   width: max-content;
   max-width: 100%;
   overflow: auto;
+  white-space: nowrap;
 }
 
 .markdown-body td,

--- a/github-markdown-light.css
+++ b/github-markdown-light.css
@@ -215,6 +215,7 @@
   width: max-content;
   max-width: 100%;
   overflow: auto;
+  white-space: nowrap;
 }
 
 .markdown-body td,

--- a/github-markdown.css
+++ b/github-markdown.css
@@ -311,6 +311,7 @@
   width: max-content;
   max-width: 100%;
   overflow: auto;
+  white-space: nowrap;
 }
 
 .markdown-body td,


### PR DESCRIPTION
Hi, 

I update from 4.0.0 and I have some display problems with tables.

**With 4.0.0**
<img width="1205" alt="Capture d’écran 2021-12-21 à 08 52 39" src="https://user-images.githubusercontent.com/1457497/146895078-c00d9160-010f-42d5-ab4c-0053d60c6a56.png">


**With 5.1.0**
<img width="1183" alt="Capture d’écran 2021-12-21 à 08 52 09" src="https://user-images.githubusercontent.com/1457497/146895115-7fd54e5c-5821-4351-ae7e-f073009f321f.png">

**On github:**
https://github.com/gravitee-io/gravitee-policy-mock
<img width="909" alt="Capture d’écran 2021-12-21 à 09 22 16" src="https://user-images.githubusercontent.com/1457497/146896224-6ccb17fe-0558-4651-a4e3-63bfbcddd92d.png">

**With the fix**

<img width="1100" alt="Capture d’écran 2021-12-21 à 09 21 18" src="https://user-images.githubusercontent.com/1457497/146895913-344b344b-42cb-40bd-b568-5b5a4189df3c.png">

