### PR TITLE
Add mention of `starry-night` to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,9 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
-If you want code syntax highlighted, use GitHub Flavored Markdown rendered from [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown).
+You can use [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown) to turn markdown into the HTML that GitHub generates, which works well with the CSS generated here. Other markdown parsers will mostly work with these styles too. To mimic how GitHub highlights code, you can use [`starry-night`](https://github.com/wooorm/starry-night) with your markdown parser of choice.
+
+If you want code syntax highlighted, use GitHub Flavored Markdown rendered from .
 
 There are 3 themes provided in this package:
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
-You can use [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown) to turn markdown into the HTML that GitHub generates, which works well with the CSS generated here. Other markdown parsers will mostly work with these styles too. To mimic how GitHub highlights code, you can use [`starry-night`](https://github.com/wooorm/starry-night) with your markdown parser of choice.
+You can use [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown) to turn Markdown into the HTML that GitHub generates, which works well with the CSS generated here. Other Markdown parsers will mostly work with these styles too. To mimic how GitHub highlights code, you can use [`starry-night`](https://github.com/wooorm/starry-night) with your Markdown parser of choice.
 
 If you want code syntax highlighted, use GitHub Flavored Markdown rendered from .
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
-You can use [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown) to turn Markdown into the HTML that GitHub generates, which works well with the CSS generated here. Other Markdown parsers will mostly work with these styles too. To mimic how GitHub highlights code, you can use [`starry-night`](https://github.com/wooorm/starry-night) with your Markdown parser of choice.
+You can use [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown) to turn Markdown into the HTML that GitHub generates, which works well with the CSS in this repo. Other Markdown parsers will mostly work with these styles too. To mimic how GitHub highlights code, you can use [`starry-night`](https://github.com/wooorm/starry-night) with your Markdown parser of choice.
 
 There are 3 themes provided in this package:
 

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,6 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 
 You can use [GitHub's `/markdown` API](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown) to turn Markdown into the HTML that GitHub generates, which works well with the CSS generated here. Other Markdown parsers will mostly work with these styles too. To mimic how GitHub highlights code, you can use [`starry-night`](https://github.com/wooorm/starry-night) with your Markdown parser of choice.
 
-If you want code syntax highlighted, use GitHub Flavored Markdown rendered from .
-
 There are 3 themes provided in this package:
 
 - **github-markdown.css**: (default) Automatically switches between light and dark through [`@media (prefers-color-scheme)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).


### PR DESCRIPTION
Closes GH-101.

I thought about it a bit and reworded the short sentence on `/markup` to explain a bit more about markdown parsers, which presumably many folks will (want to) use instead of the HTTP API. And I weaved in a mention of `starry-night`, per #101. What do you think?