### PR TITLE
Support github alerts

### DIFF
--- a/github-markdown-dark.css
+++ b/github-markdown-dark.css
@@ -1032,6 +1032,10 @@
   margin-top: 0;
 }
 
+.markdown-body .markdown-alert>:first-child svg {
+  margin-right: 0.5rem;
+}
+
 .markdown-body .markdown-alert>:last-child {
   margin-bottom: 0;
 }
@@ -1049,6 +1053,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
   color: #2f81f7;
+  fill: #2f81f7;
 }
 
 .markdown-body .markdown-alert.markdown-alert-important {
@@ -1057,6 +1062,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
   color: #a371f7;
+  fill: #a371f7;
 }
 
 .markdown-body .markdown-alert.markdown-alert-warning {
@@ -1065,6 +1071,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
   color: #d29922;
+  fill: #d29922;
 }
 
 .markdown-body .markdown-alert.markdown-alert-tip {
@@ -1073,6 +1080,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
   color: #3fb950;
+  fill: #3fb950;
 }
 
 .markdown-body .markdown-alert.markdown-alert-caution {
@@ -1081,4 +1089,5 @@
 
 .markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
   color: #f85149;
+  fill: #f85149;
 }

--- a/github-markdown-light.css
+++ b/github-markdown-light.css
@@ -1031,6 +1031,10 @@
   margin-top: 0;
 }
 
+.markdown-body .markdown-alert>:first-child svg {
+  margin-right: 0.5rem;
+}
+
 .markdown-body .markdown-alert>:last-child {
   margin-bottom: 0;
 }
@@ -1048,6 +1052,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
   color: #0969da;
+  fill: #0969da;
 }
 
 .markdown-body .markdown-alert.markdown-alert-important {
@@ -1056,6 +1061,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
   color: #8250df;
+  fill: #8250df;
 }
 
 .markdown-body .markdown-alert.markdown-alert-warning {
@@ -1064,6 +1070,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
   color: #9a6700;
+  fill: #9a6700;
 }
 
 .markdown-body .markdown-alert.markdown-alert-tip {
@@ -1072,6 +1079,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
   color: #1a7f37;
+  fill: #1a7f37;
 }
 
 .markdown-body .markdown-alert.markdown-alert-caution {
@@ -1080,4 +1088,5 @@
 
 .markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
   color: #d1242f;
+  fill: #d1242f;
 }

--- a/github-markdown.css
+++ b/github-markdown.css
@@ -112,6 +112,26 @@
   }
 }
 
+:root {
+  --base-size-4: 0.25rem;
+  --base-size-8: 0.5rem;
+  --base-size-12: 0.75rem;
+  --base-size-16: 1rem;
+  --base-size-20: 1.25rem;
+  --base-size-24: 1.5rem;
+  --base-size-28: 1.75rem;
+  --base-size-32: 2rem;
+  --base-size-36: 2.25rem;
+  --base-size-40: 2.5rem;
+  --base-size-44: 2.75rem;
+  --base-size-48: 3rem;
+  --base-size-64: 4rem;
+  --base-size-80: 5rem;
+  --base-size-96: 6rem;
+  --base-size-112: 7rem;
+  --base-size-128: 8rem;
+}
+
 .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1143,6 +1163,10 @@
   margin-top: 0;
 }
 
+.markdown-body .markdown-alert>:first-child svg {
+  margin-right: var(--base-size-8, 8px);
+}
+
 .markdown-body .markdown-alert>:last-child {
   margin-bottom: 0;
 }
@@ -1160,6 +1184,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
   color: var(--color-accent-fg);
+  fill: var(--color-accent-fg);
 }
 
 .markdown-body .markdown-alert.markdown-alert-important {
@@ -1168,6 +1193,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
   color: var(--color-done-fg);
+  fill: var(--color-done-fg);
 }
 
 .markdown-body .markdown-alert.markdown-alert-warning {
@@ -1176,6 +1202,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
   color: var(--color-attention-fg);
+  fill: var(--color-attention-fg);
 }
 
 .markdown-body .markdown-alert.markdown-alert-tip {
@@ -1184,6 +1211,7 @@
 
 .markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
   color: var(--color-success-fg);
+  fill: var(--color-success-fg);
 }
 
 .markdown-body .markdown-alert.markdown-alert-caution {
@@ -1192,4 +1220,5 @@
 
 .markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
   color: var(--color-danger-fg);
+  fill: var(--color-danger-fg);
 }


### PR DESCRIPTION
Hi :wave:,

I've noticed, actually github alerts is not completely supported, see this example:
<img width="898" alt="Capture d’écran 2024-04-13 à 17 26 01" src="https://github.com/sindresorhus/github-markdown-css/assets/76450798/a641f7d6-0227-4312-a6b2-3e356ab33336">

After updating:
<img width="898" alt="Capture d’écran 2024-04-13 à 17 26 26" src="https://github.com/sindresorhus/github-markdown-css/assets/76450798/b0474554-65e7-49ea-9c9e-3959415ff78c">

This example use the library `remark-github-blockquote-alert`

Changes made:
- Add base-size css variable 
- Add `fill` property to support svg
- Space between the icon and text

Thank you for considering this enhancement.
