### PR TITLE
docs: mention dark bg color

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,12 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 			padding: 15px;
 		}
 	}
+
+	@media (prefers-color-scheme: dark) {
+		body {
+			background-color: #0d1117;
+		}
+	}
 </style>
 <article class="markdown-body">
 	<h1>Unicorns</h1>


### PR DESCRIPTION
The default `github-markdown.css` mentioned in the example requires dark background as well.

However, the color code `#0d1117` is not mentioned in the README, so it is added in the usage code.

Referenced https://sindresorhus.com/github-markdown-css/

